### PR TITLE
fix(eth_1g_mac): Exclude CRC from axis frame.

### DIFF
--- a/rtl/axis_gmii_rx.v
+++ b/rtl/axis_gmii_rx.v
@@ -36,6 +36,7 @@ module axis_gmii_rx #
     parameter DATA_WIDTH = 8,
     parameter PTP_TS_ENABLE = 0,
     parameter PTP_TS_WIDTH = 96,
+    parameter EXCLUDE_CRC = 0,
     parameter USER_WIDTH = (PTP_TS_ENABLE ? PTP_TS_WIDTH : 0) + 1
 )
 (
@@ -144,10 +145,10 @@ reg [PTP_TS_WIDTH-1:0] ptp_ts_reg = 0;
 reg [31:0] crc_state = 32'hFFFFFFFF;
 wire [31:0] crc_next;
 
-assign m_axis_tdata = m_axis_tdata_reg[(5*DATA_WIDTH)-1:4*DATA_WIDTH];
-assign m_axis_tvalid = m_axis_tvalid_reg[4] & ~(|m_axis_tlast_reg[4:1]);
-assign m_axis_tlast = m_axis_tlast_reg[0];
-assign m_axis_tuser = PTP_TS_ENABLE ? {ptp_ts_reg, m_axis_tuser_reg[4]} : m_axis_tuser_reg[4];
+assign m_axis_tdata  = EXCLUDE_CRC ? m_axis_tdata_reg[(5*DATA_WIDTH)-1:4*DATA_WIDTH]  : m_axis_tdata_reg[DATA_WIDTH-1:0];
+assign m_axis_tvalid = EXCLUDE_CRC ? m_axis_tvalid_reg[4] & ~(|m_axis_tlast_reg[4:1]) : m_axis_tvalid_reg[0];
+assign m_axis_tlast  = m_axis_tlast_reg[0];
+assign m_axis_tuser  = PTP_TS_ENABLE ? {ptp_ts_reg, EXCLUDE_CRC? m_axis_tuser_reg[4] : m_axis_tuser_reg[0]} : (EXCLUDE_CRC ? m_axis_tuser_reg[4] : m_axis_tuser_reg[0]);
 
 assign start_packet = start_packet_reg;
 assign error_bad_frame = error_bad_frame_reg;

--- a/rtl/eth_mac_1g.v
+++ b/rtl/eth_mac_1g.v
@@ -45,7 +45,8 @@ module eth_mac_1g #
     parameter TX_USER_WIDTH = (PTP_TS_ENABLE ? (TX_PTP_TAG_ENABLE ? TX_PTP_TAG_WIDTH : 0) + (TX_PTP_TS_CTRL_IN_TUSER ? 1 : 0) : 0) + 1,
     parameter RX_USER_WIDTH = (PTP_TS_ENABLE ? PTP_TS_WIDTH : 0) + 1,
     parameter PFC_ENABLE = 0,
-    parameter PAUSE_ENABLE = PFC_ENABLE
+    parameter PAUSE_ENABLE = PFC_ENABLE,
+    parameter EXCLUDE_CRC = 0
 )
 (
     input  wire                         rx_clk,
@@ -206,7 +207,8 @@ axis_gmii_rx #(
     .DATA_WIDTH(DATA_WIDTH),
     .PTP_TS_ENABLE(PTP_TS_ENABLE),
     .PTP_TS_WIDTH(PTP_TS_WIDTH),
-    .USER_WIDTH(RX_USER_WIDTH)
+    .USER_WIDTH(RX_USER_WIDTH),
+    .EXCLUDE_CRC(EXCLUDE_CRC)
 )
 axis_gmii_rx_inst (
     .clk(rx_clk),


### PR DESCRIPTION
Ethernet 1g mac includes FCS/CRC of ethernet frame in to axis stream frame.However , CRC is now excluded from axi stream frame.